### PR TITLE
Added method getSubscribedEvents to Subscriber interface

### DIFF
--- a/src/Kdyby/Events/Subscriber.php
+++ b/src/Kdyby/Events/Subscriber.php
@@ -27,4 +27,12 @@ use Nette;
 interface Subscriber extends Doctrine\Common\EventSubscriber
 {
 
+	/**
+	 * Defines array of subscribed events
+	 *
+	 * @return array
+	 */
+	function getSubscribedEvents();
+
+
 }


### PR DESCRIPTION
In my opinion there should be defined method 'getSubscribedEvents' in 'Subscriber' interface.
