### PR TITLE
Resolved compatibility with original Doctrine EventManager

### DIFF
--- a/tests/KdybyTests/Events/EventManager.phpt
+++ b/tests/KdybyTests/Events/EventManager.phpt
@@ -43,7 +43,7 @@ class EventManagerTest extends Tester\TestCase
 		$listener = new EventListenerMock();
 		$this->manager->addEventListener('onFoo', $listener);
 		Assert::true($this->manager->hasListeners('onFoo'));
-		Assert::same(array($listener), $this->manager->getListeners());
+		Assert::same(array('onFoo' => array($listener)), $this->manager->getListeners());
 	}
 
 

--- a/tests/KdybyTests/Events/Extension.phpt
+++ b/tests/KdybyTests/Events/Extension.phpt
@@ -48,7 +48,7 @@ class ExtensionTest extends Tester\TestCase
 		$manager = $container->getService('events.manager');
 		/** @var Kdyby\Events\EventManager $manager */
 		Assert::true($manager instanceof Kdyby\Events\EventManager);
-		Assert::equal(1, count($manager->getListeners()));
+		Assert::equal(2, count($manager->getListeners()));
 	}
 
 

--- a/tests/KdybyTests/Events/LazyEventManager.phpt
+++ b/tests/KdybyTests/Events/LazyEventManager.phpt
@@ -82,8 +82,13 @@ class LazyEventManagerTest extends Tester\TestCase
 		Assert::true($sl->isCreated('second'));
 
 		Assert::same(array(
-			$sl->getService('first'),
-			$sl->getService('second'),
+			'onFoo' => array(
+				$sl->getService('first'),
+				$sl->getService('second'),
+			),
+			'onBar' => array(
+				$sl->getService('second'),
+			),
 		), $all);
 	}
 


### PR DESCRIPTION
Calling getListeners() without arg returns array of arrays of listeners.

[Fixes #22]
