### PR TITLE
Fixed compatibility with Nette

### DIFF
--- a/src/Kdyby/Events/Diagnostics/Panel.php
+++ b/src/Kdyby/Events/Diagnostics/Panel.php
@@ -17,10 +17,14 @@ use Kdyby\Events\EventManager;
 use Nette;
 use Nette\Diagnostics\Bar;
 use Nette\Diagnostics\Debugger;
-use Nette\Iterators\CachingIterator;
+use Nette\Latte\Runtime\CachingIterator;
 use Nette\Utils\Arrays;
 
 
+
+if (!class_exists('Nette\Latte\Runtime\CachingIterator')) {
+	class_alias('Nette\Iterators\CachingIterator', 'Nette\Latte\Runtime\CachingIterator');
+}
 
 /**
  * @author Filip Procházka <filip@prochazka.su>


### PR DESCRIPTION
CachingIterator was renamed: https://github.com/nette/nette/commit/f2d7d8db8ae1fc5c94f2ebc184b0d26e0c532029
