### PR TITLE
Added support for children class subscriber

### DIFF
--- a/tests/KdybyTests/Events/Extension.phpt
+++ b/tests/KdybyTests/Events/Extension.phpt
@@ -116,6 +116,30 @@ class ExtensionTest extends Tester\TestCase
 
 
 
+	public function testInherited()
+	{
+		$container = $this->createContainer('inherited');
+
+		$leafObject = $container->getService('leaf');
+		/** @var LeafClass $leafObject */
+		Assert::true($leafObject->onCreate instanceof Kdyby\Events\Event);
+		Assert::same('KdybyTests\Events\ParentClass::onCreate', $leafObject->onCreate->getName());
+
+		$subscriber = $container->getService('subscriber');
+		/** @var InheritSubscriber $subscriber */
+		$leafObject->create();
+		Assert::true(isset($subscriber->eventCalls['KdybyTests\Events\ParentClass::onCreate']));
+		Assert::equal(1, $subscriber->eventCalls['KdybyTests\Events\ParentClass::onCreate']);
+
+		Assert::true(isset($subscriber->eventCalls['KdybyTests\Events\LeafClass::onCreate']));
+		Assert::equal(1, $subscriber->eventCalls['KdybyTests\Events\LeafClass::onCreate']);
+
+		// not subscribed for middle class
+		Assert::false(isset($subscriber->eventCalls['KdybyTests\Events\InheritedClass::onCreate']));
+	}
+
+
+
 	public function testOptimize()
 	{
 		$container = $this->createContainer('optimize');

--- a/tests/KdybyTests/Events/config/inherited.neon
+++ b/tests/KdybyTests/Events/config/inherited.neon
@@ -1,0 +1,12 @@
+events:
+	optimize: no
+	validate: no
+	autowire: yes
+	subscribers:
+		
+
+services:
+	leaf: KdybyTests\Events\LeafClass
+	subscriber:
+		class: KdybyTests\Events\InheritSubscriber
+		tags: [kdyby.subscriber]

--- a/tests/KdybyTests/Events/mocks.php
+++ b/tests/KdybyTests/Events/mocks.php
@@ -454,3 +454,47 @@ class SampleExceptionHandler implements Kdyby\Events\IExceptionHandler
 	}
 
 }
+
+
+class ParentClass extends Nette\Object
+{
+	public $onCreate;
+
+	public function create() {
+		$this->onCreate();
+	}
+}
+
+class InheritedClass extends ParentClass
+{
+}
+
+class LeafClass extends InheritedClass
+{
+	
+}
+
+class InheritSubscriber implements Kdyby\Events\Subscriber
+{
+	public $eventCalls = array();
+
+	/**
+	 * @return array
+	 */
+	public function getSubscribedEvents()
+	{
+		return array(
+			'KdybyTests\Events\LeafClass::onCreate',
+			'KdybyTests\Events\ParentClass::onCreate',
+		);
+	}
+
+
+
+	public function onCreate() {
+		$backtrace = debug_backtrace();
+		$event = $backtrace[2]['args'][0];
+		$this->eventCalls[$event] = 1 + (isset($this->eventCalls[$event]) ? $this->eventCalls[$event] : 0);
+	}
+
+}


### PR DESCRIPTION
This patch add ability to subscribe events for specific children class.

Example:
For event Nette\UI\Presenter::onShutdown it allows subscribe for specific presenter like SomePresenter::onShutdown 
