### PR TITLE
Removed compatibility code

### DIFF
--- a/src/Kdyby/Events/DI/EventsExtension.php
+++ b/src/Kdyby/Events/DI/EventsExtension.php
@@ -17,17 +17,6 @@ use Nette\Utils\AssertionException;
 
 
 
-if (!class_exists('Nette\DI\CompilerExtension')) {
-	class_alias('Nette\Config\CompilerExtension', 'Nette\DI\CompilerExtension');
-	class_alias('Nette\Config\Compiler', 'Nette\DI\Compiler');
-	class_alias('Nette\Config\Helpers', 'Nette\DI\Config\Helpers');
-}
-
-if (isset(Nette\Loaders\NetteLoader::getInstance()->renamed['Nette\Configurator']) || !class_exists('Nette\Configurator')) {
-	unset(Nette\Loaders\NetteLoader::getInstance()->renamed['Nette\Configurator']); // fuck you
-	class_alias('Nette\Config\Configurator', 'Nette\Configurator');
-}
-
 /**
  * @author Filip Procházka <filip@prochazka.su>
  */


### PR DESCRIPTION
Without nette/nette package the class Nette\Loaders\NetteLoader does not exist which causes a fatal error.
