### PR TITLE
failing test: multiple method aliases w/o priority

### DIFF
--- a/tests/KdybyTests/Events/EventManager.phpt
+++ b/tests/KdybyTests/Events/EventManager.phpt
@@ -194,6 +194,20 @@ class EventManagerTest extends Tester\TestCase
 
 
 
+	public function testEventsDispatching_MultipleMethodAliases()
+	{
+		$this->manager->addEventSubscriber($listener = new MultipleMethodAliasesListenerMock());
+
+		$this->manager->dispatchEvent('onDiscard', $args = new EventArgsMock());
+
+		Assert::same(array(
+			array(__NAMESPACE__ . '\\MethodAliasListenerMock::customMethodA', array($args)),
+			array(__NAMESPACE__ . '\\MethodAliasListenerMock::customMethodB', array($args)),
+		), $listener->calls);
+	}
+
+
+
 	public function testEventsDispatching_Priority()
 	{
 		$this->manager->addEventSubscriber($lower = new PriorityMethodAliasListenerMock());

--- a/tests/KdybyTests/Events/config/optimize.neon
+++ b/tests/KdybyTests/Events/config/optimize.neon
@@ -20,6 +20,10 @@ services:
 		class: KdybyTests\Events\MethodAliasListenerMock
 		tags: [kdyby.subscriber]
 
+	MultipleMethodAliases:
+		class: KdybyTests\Events\MultipleMethodAliasesListenerMock
+		tags: [kdyby.subscriber]
+
 	priorityMethod:
 		class: KdybyTests\Events\PriorityMethodAliasListenerMock
 		tags: [kdyby.subscriber]

--- a/tests/KdybyTests/Events/mocks.php
+++ b/tests/KdybyTests/Events/mocks.php
@@ -239,6 +239,36 @@ class MethodAliasListenerMock extends Nette\Object implements Kdyby\Events\Subsc
 
 
 
+class MultipleMethodAliasesListenerMock extends Nette\Object implements Kdyby\Events\Subscriber
+{
+
+	public $calls = array();
+
+	public function getSubscribedEvents()
+	{
+		return array(
+			'Article::onDiscard' => array(
+				'customMethodA',
+				'customMethodB',
+			),
+		);
+	}
+
+	public function customMethodA(EventArgsMock $args)
+	{
+		$args->calls[] = array(__METHOD__, func_get_args());
+		$this->calls[] = array(__METHOD__, func_get_args());
+	}
+
+	public function customMethodB(EventArgsMock $args)
+	{
+		$args->calls[] = array(__METHOD__, func_get_args());
+		$this->calls[] = array(__METHOD__, func_get_args());
+	}
+}
+
+
+
 /**
  * @author Filip Procházka <filip@prochazka.su>
  */


### PR DESCRIPTION
```php
public function getSubscribedEvents()
{
	return [
		'Foo::onbar' => [
			'methodA',
			'methodB',
		],
	];
}
```
should work.
Will try to fix it when I have more time.