### PR TITLE
Incorrect ServiceDefinition::getClass call

### DIFF
--- a/src/Kdyby/Events/DI/EventsExtension.php
+++ b/src/Kdyby/Events/DI/EventsExtension.php
@@ -346,7 +346,7 @@ class EventsExtension extends Nette\DI\CompilerExtension
 
 				// find all subclasses and register the listener to all the classes dispatching them
 				foreach ($builder->getDefinitions() as $def) {
-					if (!$class = $def->getClass()) {
+					if (!$class = $def->class) {
 						continue; // ignore unresolved classes
 					}
 


### PR DESCRIPTION
![snimek obrazovky porizeny 2015-01-22 10 34 56](https://cloud.githubusercontent.com/assets/5060034/5853271/5a57cb0a-a222-11e4-8959-f6bf1b2e7e74.png)
Calling Nette\DI\ServiceDefinition::getClass will raise Nette\MemberAccessException. I propose to use direct access to Nette\DI\ServiceDefinition::$class. Tested on Nette 2.1.9.