### PR TITLE
Panel: fixed $shortFilename callback typehint

### DIFF
--- a/src/Kdyby/Events/Diagnostics/Panel.php
+++ b/src/Kdyby/Events/Diagnostics/Panel.php
@@ -388,7 +388,7 @@ class Panel extends Nette\Object implements Tracy\IBarPanel
 
 		$h = 'htmlspecialchars';
 
-		$shortFilename = function (Nette\Reflection\GlobalFunction $refl) {
+		$shortFilename = function (\ReflectionMethod $refl) {
 			$title = '.../' . basename($refl->getFileName()) . ':' . $refl->getStartLine();
 
 			if ($editor = Tracy\Helpers::editorUri($refl->getFileName(), $refl->getStartLine())) {


### PR DESCRIPTION
`Nette\Utils\Callback::toReflection()` returns `\ReflectionMethod`, which was causing an `ErrorException`.