### PR TITLE
Removed useless use statements

### DIFF
--- a/src/Kdyby/Events/LifeCycleEvent.php
+++ b/src/Kdyby/Events/LifeCycleEvent.php
@@ -11,9 +11,6 @@
 namespace Kdyby\Events;
 
 use Kdyby;
-use Nette\Application\Application;
-use Nette\Application\IResponse;
-use Nette\Application\Request;
 use Nette;
 
 


### PR DESCRIPTION
Technically the `use Kdyby;` statement is useless as well but you do have it everywhere for whatever reason.