### PR TITLE
fixed duplicate service creation using alias in Nette 2.3

### DIFF
--- a/src/Kdyby/Events/DI/EventsExtension.php
+++ b/src/Kdyby/Events/DI/EventsExtension.php
@@ -266,6 +266,13 @@ class EventsExtension extends Nette\DI\CompilerExtension
 	}
 
 
+	private function isAlias(Nette\DI\ServiceDefinition $definition)
+	{
+		return $definition->factory instanceof Nette\DI\Statement
+			&& ($definition->factory->entity instanceof Nette\DI\ServiceDefinition
+				|| (is_string($definition->factory->entity) && $definition->factory->entity{0} === '@')
+			);
+	}
 
 	/**
 	 * @param \Nette\DI\ContainerBuilder $builder
@@ -274,7 +281,7 @@ class EventsExtension extends Nette\DI\CompilerExtension
 	{
 		foreach ($builder->getDefinitions() as $def) {
 			/** @var Nette\DI\ServiceDefinition $def */
-			if ($def->factory instanceof Nette\DI\Statement && $def->factory->entity instanceof Nette\DI\ServiceDefinition) {
+			if ($this->isAlias($def)) {
 				continue; // alias
 			}
 

--- a/tests/KdybyTests/Events/Extension.phpt
+++ b/tests/KdybyTests/Events/Extension.phpt
@@ -285,6 +285,11 @@ class ExtensionTest extends Tester\TestCase
 		Assert::true($handler instanceof Kdyby\Events\IExceptionHandler);
 	}
 
+	public function testAutowireAlias() {
+		$container = $this->createContainer('alias');
+		Assert::same($container->getService('alias'), $container->getService('application'));
+	}
+
 }
 
 \run(new ExtensionTest());

--- a/tests/KdybyTests/Events/config/alias.neon
+++ b/tests/KdybyTests/Events/config/alias.neon
@@ -1,0 +1,10 @@
+events:
+	optimize: no
+	validate: no
+	autowire: yes
+
+services:
+	application:
+		class: NULL
+		factory: Nette\Application\Application
+	alias: @application


### PR DESCRIPTION
In Nette 2.3, alias services are defined slightly differently / $serviceDefinition->factory->entity is the service definition string (i.e. '@referredService') to beforeCompile(), not as a parsed Nette\DI\ServiceDefinition objects. Therefore the service alias was not correctly recognized as an alias, so an alias to event receiver created new instance of the service. With this fix, alias is properly recognized in Nette 2.3.