### PR TITLE
Fixed setting of sorted array of listeners in EventManager to empty a…

### DIFF
--- a/src/Kdyby/Events/EventManager.php
+++ b/src/Kdyby/Events/EventManager.php
@@ -231,10 +231,10 @@ class EventManager extends Doctrine\Common\EventManager
 				}
 				if (empty($this->listeners[$eventName])) {
 					unset($this->listeners[$eventName]);
-				}
 
-				// there are no listeners for this specific event, so no reason to call sort on next dispatch
-				$this->sorted[$eventName] = array();
+					// there are no listeners for this specific event, so no reason to call sort on next dispatch
+					$this->sorted[$eventName] = array();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
`Kdyby\Events\EventManager::sorted[$eventName]` is set to an empty array even when there are more subscribers for the same event. It's enough to remove one and it effectively removes all of them, because when the event is dispatched, the EventManager looks at this array and doesn't find any listeners, even tough there are still some in `Kdyby\Events\EventManager::listeners`.

This pull request should fix this issue. Now, the array is only set to an empty array after explicit check, that `listeners[$eventName]` array is also empty.

The addressed issue is described more in depth [here](https://github.com/Kdyby/Events/issues/80).