### PR TITLE
EventManager: Alow callable as listeners [Closes #57]

### DIFF
--- a/src/Kdyby/Events/EventManager.php
+++ b/src/Kdyby/Events/EventManager.php
@@ -171,7 +171,7 @@ class EventManager extends Doctrine\Common\EventManager
 	 * Adds an event listener that listens on the specified events.
 	 *
 	 * @param string|array $events The event(s) to listen on.
-	 * @param Doctrine\Common\EventSubscriber|array $subscriber The listener object.
+	 * @param Doctrine\Common\EventSubscriber|array|callable $subscriber The listener object.
 	 * @param int $priority
 	 *
 	 * @throws InvalidListenerException
@@ -180,10 +180,11 @@ class EventManager extends Doctrine\Common\EventManager
 	{
 		foreach ((array) $events as $eventName) {
 			list($namespace, $event) = Event::parseName($eventName);
-			$callback = !is_array($subscriber) ? array($subscriber, $event) : $subscriber;
+			$callback = !is_callable($subscriber) ? [$subscriber, $event] : $subscriber;
 
-			if (!method_exists($callback[0], $callback[1])) {
-				throw new InvalidListenerException("Event listener '" . get_class($callback[0]) . "' has no method '" . $callback[1] . "'");
+			if (!is_callable($callback)) {
+				throw new InvalidListenerException("Event listener '" . get_class($callback[0]) .
+					"' is not callable and has no method '" . $callback[1] . "'");
 			}
 
 			$this->listeners[$eventName][$priority][] = $subscriber;

--- a/src/Kdyby/Events/EventManager.php
+++ b/src/Kdyby/Events/EventManager.php
@@ -183,8 +183,12 @@ class EventManager extends Doctrine\Common\EventManager
 			$callback = !is_callable($subscriber) ? [$subscriber, $event] : $subscriber;
 
 			if (!is_callable($callback)) {
-				throw new InvalidListenerException("Event listener '" . get_class($callback[0]) .
-					"' is not callable and has no method '" . $callback[1] . "'");
+				if (is_object($callback[0])) {
+					throw new InvalidListenerException("Event listener '" . get_class($callback[0]) . "'  has no method '" . $callback[1] . "'");
+				} else {
+					throw new InvalidListenerException("Event listener '" . $callback[0] .
+						"' is not callable.");
+				}
 			}
 
 			$this->listeners[$eventName][$priority][] = $subscriber;

--- a/src/Kdyby/Events/EventManager.php
+++ b/src/Kdyby/Events/EventManager.php
@@ -180,7 +180,7 @@ class EventManager extends Doctrine\Common\EventManager
 	{
 		foreach ((array) $events as $eventName) {
 			list($namespace, $event) = Event::parseName($eventName);
-			$callback = !is_callable($subscriber) ? [$subscriber, $event] : $subscriber;
+			$callback = !is_callable($subscriber) ? array($subscriber, $event) : $subscriber;
 
 			if (!is_callable($callback)) {
 				if (is_object($callback[0])) {

--- a/src/Kdyby/Events/LazyEventManager.php
+++ b/src/Kdyby/Events/LazyEventManager.php
@@ -110,11 +110,15 @@ class LazyEventManager extends EventManager
 		foreach ($this->listenerIds[$eventName] as $serviceName) {
 			if (is_callable($serviceName)) {
 				$this->addEventListener($eventName, $serviceName);
-			} else {
-				$subscriber = $this->container->getService($serviceName);
-				/** @var Doctrine\Common\EventSubscriber $subscriber */
+				continue;
+			}
 
-				$this->addEventSubscriber($subscriber);
+			$listener = $this->container->getService($serviceName);
+			if (is_callable($listener)) {
+				$this->addEventListener($eventName, $listener);
+			} else {
+				/** @var Doctrine\Common\EventSubscriber $listener */
+				$this->addEventSubscriber($listener);
 			}
 		}
 

--- a/src/Kdyby/Events/LazyEventManager.php
+++ b/src/Kdyby/Events/LazyEventManager.php
@@ -81,12 +81,14 @@ class LazyEventManager extends EventManager
 
 	/**
 	 * @param array|string $unsubscribe
-	 * @param Doctrine\Common\EventSubscriber|array $subscriber
+	 * @param Doctrine\Common\EventSubscriber|array|callable $subscriber
 	 */
 	public function removeEventListener($unsubscribe, $subscriber = NULL)
 	{
 		if ($unsubscribe instanceof EventSubscriber) {
 			list($unsubscribe, $subscriber) = $this->extractSubscriber($unsubscribe);
+		} elseif (is_callable($unsubscribe)) {
+			list($unsubscribe, $subscriber) = $this->extractCallable($unsubscribe);
 		}
 
 		foreach ((array) $unsubscribe as $eventName) {
@@ -106,10 +108,14 @@ class LazyEventManager extends EventManager
 	private function initializeListener($eventName)
 	{
 		foreach ($this->listenerIds[$eventName] as $serviceName) {
-			$subscriber = $this->container->getService($serviceName);
-			/** @var Doctrine\Common\EventSubscriber $subscriber */
+			if (is_callable($serviceName)) {
+				$this->addEventListener($eventName, $serviceName);
+			} else {
+				$subscriber = $this->container->getService($serviceName);
+				/** @var Doctrine\Common\EventSubscriber $subscriber */
 
-			$this->addEventSubscriber($subscriber);
+				$this->addEventSubscriber($subscriber);
+			}
 		}
 
 		unset($this->listenerIds[$eventName]);

--- a/tests/KdybyTests/Events/EventManager.phpt
+++ b/tests/KdybyTests/Events/EventManager.phpt
@@ -58,26 +58,44 @@ class EventManagerTest extends Tester\TestCase
 
 
 
+	public function testListenerMagic()
+	{
+		$listener = new MagicEventListenerMock();
+		$this->manager->addEventListener('onBaz', $listener);
+		Assert::true($this->manager->hasListeners('onBaz'));
+		Assert::same(array('onBaz' => array($listener)), $this->manager->getListeners());
+	}
+
+
+
 	public function testRemovingListenerFromSpecificEvent()
 	{
 		$listenerClass = new EventListenerMock();
 		$listenerCallback = function () {};
+		$listenerMagic = new MagicEventListenerMock();
 
 		$this->manager->addEventListener('onFoo', $listenerClass);
 		$this->manager->addEventListener('onBar', $listenerClass);
 		$this->manager->addEventListener('onBaz', $listenerCallback);
 		$this->manager->addEventListener('onQux', $listenerCallback);
+		$this->manager->addEventListener('onQuux', $listenerMagic);
+		$this->manager->addEventListener('onCorge', $listenerMagic);
 		Assert::true($this->manager->hasListeners('onFoo'));
 		Assert::true($this->manager->hasListeners('onBar'));
 		Assert::true($this->manager->hasListeners('onBaz'));
 		Assert::true($this->manager->hasListeners('onQux'));
+		Assert::true($this->manager->hasListeners('onQuux'));
+		Assert::true($this->manager->hasListeners('onCorge'));
 
 		$this->manager->removeEventListener('onFoo', $listenerClass);
 		$this->manager->removeEventListener('onBaz', $listenerCallback);
+		$this->manager->removeEventListener('onQuux', $listenerMagic);
 		Assert::false($this->manager->hasListeners('onFoo'));
 		Assert::true($this->manager->hasListeners('onBar'));
 		Assert::false($this->manager->hasListeners('onBaz'));
 		Assert::true($this->manager->hasListeners('onQux'));
+		Assert::false($this->manager->hasListeners('onQuux'));
+		Assert::true($this->manager->hasListeners('onCorge'));
 	}
 
 
@@ -86,22 +104,30 @@ class EventManagerTest extends Tester\TestCase
 	{
 		$listenerClass = new EventListenerMock();
 		$listenerCallback = function () {};
+		$listenerMagic = new MagicEventListenerMock();
 
 		$this->manager->addEventListener('onFoo', $listenerClass);
 		$this->manager->addEventListener('onBar', $listenerClass);
 		$this->manager->addEventListener('onBaz', $listenerCallback);
 		$this->manager->addEventListener('onQux', $listenerCallback);
+		$this->manager->addEventListener('onQuux', $listenerMagic);
+		$this->manager->addEventListener('onCorge', $listenerMagic);
 		Assert::true($this->manager->hasListeners('onFoo'));
 		Assert::true($this->manager->hasListeners('onBar'));
 		Assert::true($this->manager->hasListeners('onBaz'));
 		Assert::true($this->manager->hasListeners('onQux'));
+		Assert::true($this->manager->hasListeners('onQuux'));
+		Assert::true($this->manager->hasListeners('onCorge'));
 
 		$this->manager->removeEventListener($listenerClass);
 		$this->manager->removeEventListener($listenerCallback);
+		$this->manager->removeEventListener($listenerMagic);
 		Assert::false($this->manager->hasListeners('onFoo'));
 		Assert::false($this->manager->hasListeners('onBar'));
 		Assert::false($this->manager->hasListeners('onBaz'));
 		Assert::false($this->manager->hasListeners('onQux'));
+		Assert::false($this->manager->hasListeners('onQuux'));
+		Assert::false($this->manager->hasListeners('onCorge'));
 		Assert::same([], $this->manager->getListeners());
 	}
 
@@ -177,6 +203,23 @@ class EventManagerTest extends Tester\TestCase
 		$this->manager->dispatchEvent('onBar', $eventArgs);
 
 		Assert::same(2, $triggerCounter);
+	}
+
+
+
+	public function testDispatchingMagic()
+	{
+		$listener = new MagicEventListenerMock();
+		$this->manager->addEventSubscriber($listener);
+		Assert::true($this->manager->hasListeners('onQuux'));
+		Assert::true($this->manager->hasListeners('onCorge'));
+
+		$eventArgs = new EventArgsMock();
+		$this->manager->dispatchEvent('onQuux', $eventArgs);
+
+		Assert::same(array(
+			array('KdybyTests\Events\MagicEventListenerMock::onQuux', array($eventArgs))
+		), $listener->calls);
 	}
 
 

--- a/tests/KdybyTests/Events/EventManager.phpt
+++ b/tests/KdybyTests/Events/EventManager.phpt
@@ -60,31 +60,49 @@ class EventManagerTest extends Tester\TestCase
 
 	public function testRemovingListenerFromSpecificEvent()
 	{
-		$listener = new EventListenerMock();
-		$this->manager->addEventListener('onFoo', $listener);
-		$this->manager->addEventListener('onBar', $listener);
+		$listenerClass = new EventListenerMock();
+		$listenerCallback = function () {};
+
+		$this->manager->addEventListener('onFoo', $listenerClass);
+		$this->manager->addEventListener('onBar', $listenerClass);
+		$this->manager->addEventListener('onBaz', $listenerCallback);
+		$this->manager->addEventListener('onQux', $listenerCallback);
 		Assert::true($this->manager->hasListeners('onFoo'));
 		Assert::true($this->manager->hasListeners('onBar'));
+		Assert::true($this->manager->hasListeners('onBaz'));
+		Assert::true($this->manager->hasListeners('onQux'));
 
-		$this->manager->removeEventListener('onFoo', $listener);
+		$this->manager->removeEventListener('onFoo', $listenerClass);
+		$this->manager->removeEventListener('onBaz', $listenerCallback);
 		Assert::false($this->manager->hasListeners('onFoo'));
 		Assert::true($this->manager->hasListeners('onBar'));
+		Assert::false($this->manager->hasListeners('onBaz'));
+		Assert::true($this->manager->hasListeners('onQux'));
 	}
 
 
 
 	public function testRemovingListenerCompletely()
 	{
-		$listener = new EventListenerMock();
-		$this->manager->addEventListener('onFoo', $listener);
-		$this->manager->addEventListener('onBar', $listener);
+		$listenerClass = new EventListenerMock();
+		$listenerCallback = function () {};
+
+		$this->manager->addEventListener('onFoo', $listenerClass);
+		$this->manager->addEventListener('onBar', $listenerClass);
+		$this->manager->addEventListener('onBaz', $listenerCallback);
+		$this->manager->addEventListener('onQux', $listenerCallback);
 		Assert::true($this->manager->hasListeners('onFoo'));
 		Assert::true($this->manager->hasListeners('onBar'));
+		Assert::true($this->manager->hasListeners('onBaz'));
+		Assert::true($this->manager->hasListeners('onQux'));
 
-		$this->manager->removeEventListener($listener);
+		$this->manager->removeEventListener($listenerClass);
+		$this->manager->removeEventListener($listenerCallback);
 		Assert::false($this->manager->hasListeners('onFoo'));
 		Assert::false($this->manager->hasListeners('onBar'));
-		Assert::same(array(), $this->manager->getListeners());
+		Assert::false($this->manager->hasListeners('onBaz'));
+		Assert::false($this->manager->hasListeners('onQux'));
+		Assert::same([], $this->manager->getListeners());
 	}
 
 

--- a/tests/KdybyTests/Events/EventManager.phpt
+++ b/tests/KdybyTests/Events/EventManager.phpt
@@ -48,6 +48,16 @@ class EventManagerTest extends Tester\TestCase
 
 
 
+	public function testListenerIsCallable()
+	{
+		$listener = function () {};
+		$this->manager->addEventListener('onFoo', $listener);
+		Assert::true($this->manager->hasListeners('onFoo'));
+		Assert::same(array('onFoo' => array($listener)), $this->manager->getListeners());
+	}
+
+
+
 	public function testRemovingListenerFromSpecificEvent()
 	{
 		$listener = new EventListenerMock();
@@ -122,6 +132,33 @@ class EventManagerTest extends Tester\TestCase
 		Assert::same(array(
 			array('KdybyTests\Events\EventListenerMock::onFoo', array($eventArgs))
 		), $listener->calls);
+	}
+
+
+
+	public function testDispatchingCallable()
+	{
+		$triggerCounter = 0;
+		$listener = function () use (& $triggerCounter) {
+			$triggerCounter++;
+		};
+
+		$this->manager->addEventListener('onFoo', $listener);
+		$this->manager->addEventListener('onBar', $listener);
+		Assert::true($this->manager->hasListeners('onFoo'));
+		Assert::true($this->manager->hasListeners('onBar'));
+
+		Assert::same(0, $triggerCounter);
+
+		$eventArgs = new EventArgsMock();
+		$this->manager->dispatchEvent('onFoo', $eventArgs);
+
+		Assert::same(1, $triggerCounter);
+
+		$eventArgs = new EventArgsMock();
+		$this->manager->dispatchEvent('onBar', $eventArgs);
+
+		Assert::same(2, $triggerCounter);
 	}
 
 

--- a/tests/KdybyTests/Events/LazyEventManager.phpt
+++ b/tests/KdybyTests/Events/LazyEventManager.phpt
@@ -33,9 +33,6 @@ class LazyEventManagerTest extends Tester\TestCase
 	{
 		$sl = new ListenersContainer();
 
-		$baz = function () {};
-		$sl->addService('baz', $baz);
-
 		$lazy = new LazyEventManager(array(
 			'App::onFoo' => array(
 				'first',
@@ -46,11 +43,11 @@ class LazyEventManagerTest extends Tester\TestCase
 			'onBar' => array(
 				'second',
 			),
-			'onBaz' => array(
-				$baz,
-			),
 			'Article::onDiscard' => array(
 				'third',
+			),
+			'onBaz' => array(
+				'fourth',
 			),
 		), $sl);
 
@@ -74,7 +71,7 @@ class LazyEventManagerTest extends Tester\TestCase
 		Assert::true($sl->isCreated('second'));
 
 		Assert::same(array($sl->getService('second')), $fooListener);
-		Assert::same(array($sl->getService('baz')), $bazListener);
+		Assert::same(array($sl->getService('fourth')), $bazListener);
 	}
 
 
@@ -104,14 +101,14 @@ class LazyEventManagerTest extends Tester\TestCase
 			'onBar' => array(
 				$sl->getService('second'),
 			),
-			'onBaz' => array(
-				$sl->getService('baz'),
-			),
 			'Article::onDiscard' => array(
 				array(
 					$sl->getService('third'),
 					'customMethod'
 				)
+			),
+			'onBaz' => array(
+				$sl->getService('fourth'),
 			),
 		), $all);
 	}
@@ -126,7 +123,7 @@ class LazyEventManagerTest extends Tester\TestCase
 		$first = $sl->getService('first');
 		$second = $sl->getService('second');
 		$third = $sl->getService('third');
-		$baz = $sl->getService('baz');
+		$fourth = $sl->getService('fourth');
 
 		Assert::true($lazy->hasListeners('App::onFoo'));
 		Assert::true($lazy->hasListeners('onFoo'));
@@ -137,7 +134,7 @@ class LazyEventManagerTest extends Tester\TestCase
 		$lazy->removeEventSubscriber($first);
 		$lazy->removeEventSubscriber($second);
 		$lazy->removeEventSubscriber($third);
-		$lazy->removeEventListener($baz); // callable is listener, not subscriber
+		$lazy->removeEventListener($fourth); // callable is listener, not subscriber
 
 		Assert::false($lazy->hasListeners('App::onFoo'));
 		Assert::false($lazy->hasListeners('onFoo'));
@@ -170,6 +167,13 @@ class ListenersContainer extends Container
 	protected function createServiceThird()
 	{
 		return new MethodAliasListenerMock();
+	}
+
+
+
+	protected function createServiceFourth()
+	{
+		return function () {};
 	}
 
 }

--- a/tests/KdybyTests/Events/LazyEventManager.phpt
+++ b/tests/KdybyTests/Events/LazyEventManager.phpt
@@ -33,6 +33,9 @@ class LazyEventManagerTest extends Tester\TestCase
 	{
 		$sl = new ListenersContainer();
 
+		$baz = function () {};
+		$sl->addService('baz', $baz);
+
 		$lazy = new LazyEventManager(array(
 			'App::onFoo' => array(
 				'first',
@@ -42,6 +45,9 @@ class LazyEventManagerTest extends Tester\TestCase
 			),
 			'onBar' => array(
 				'second',
+			),
+			'onBaz' => array(
+				$baz,
 			),
 			'Article::onDiscard' => array(
 				'third',
@@ -62,11 +68,13 @@ class LazyEventManagerTest extends Tester\TestCase
 		Assert::false($sl->isCreated('second'));
 
 		$fooListener = $lazy->getListeners('onFoo');
+		$bazListener = $lazy->getListeners('onBaz');
 
 		Assert::false($sl->isCreated('first'));
 		Assert::true($sl->isCreated('second'));
 
 		Assert::same(array($sl->getService('second')), $fooListener);
+		Assert::same(array($sl->getService('baz')), $bazListener);
 	}
 
 
@@ -96,6 +104,9 @@ class LazyEventManagerTest extends Tester\TestCase
 			'onBar' => array(
 				$sl->getService('second'),
 			),
+			'onBaz' => array(
+				$sl->getService('baz'),
+			),
 			'Article::onDiscard' => array(
 				array(
 					$sl->getService('third'),
@@ -115,19 +126,23 @@ class LazyEventManagerTest extends Tester\TestCase
 		$first = $sl->getService('first');
 		$second = $sl->getService('second');
 		$third = $sl->getService('third');
+		$baz = $sl->getService('baz');
 
 		Assert::true($lazy->hasListeners('App::onFoo'));
 		Assert::true($lazy->hasListeners('onFoo'));
 		Assert::true($lazy->hasListeners('onBar'));
+		Assert::true($lazy->hasListeners('onBaz'));
 		Assert::true($lazy->hasListeners('Article::onDiscard'));
 
 		$lazy->removeEventSubscriber($first);
 		$lazy->removeEventSubscriber($second);
 		$lazy->removeEventSubscriber($third);
+		$lazy->removeEventListener($baz); // callable is listener, not subscriber
 
 		Assert::false($lazy->hasListeners('App::onFoo'));
 		Assert::false($lazy->hasListeners('onFoo'));
 		Assert::false($lazy->hasListeners('onBar'));
+		Assert::false($lazy->hasListeners('onBaz'));
 		Assert::false($lazy->hasListeners('Article::onDiscard'));
 	}
 

--- a/tests/KdybyTests/Events/LazyEventManager.phpt
+++ b/tests/KdybyTests/Events/LazyEventManager.phpt
@@ -49,6 +49,9 @@ class LazyEventManagerTest extends Tester\TestCase
 			'onBaz' => array(
 				'fourth',
 			),
+			'onQuux' => array(
+				'fifth',
+			),
 		), $sl);
 
 		return array(array($sl, $lazy));
@@ -63,18 +66,22 @@ class LazyEventManagerTest extends Tester\TestCase
 	{
 		Assert::false($sl->isCreated('first'));
 		Assert::false($sl->isCreated('second'));
+		Assert::false($sl->isCreated('fourth'));
+		Assert::false($sl->isCreated('fifth'));
 
 		$fooListener = $lazy->getListeners('onFoo');
 		$bazListener = $lazy->getListeners('onBaz');
+		$quuxListener = $lazy->getListeners('onQuux');
 
 		Assert::false($sl->isCreated('first'));
 		Assert::true($sl->isCreated('second'));
+		Assert::true($sl->isCreated('fourth'));
+		Assert::true($sl->isCreated('fifth'));
 
-		Assert::same(array($sl->getService('second')), $fooListener);
-		Assert::same(array($sl->getService('fourth')), $bazListener);
+		Assert::same([$sl->getService('second')], $fooListener);
+		Assert::same([$sl->getService('fourth')], $bazListener);
+		Assert::same([$sl->getService('fifth')], $quuxListener);
 	}
-
-
 
 	/**
 	 * @dataProvider dateGetListeners
@@ -84,12 +91,16 @@ class LazyEventManagerTest extends Tester\TestCase
 		Assert::false($sl->isCreated('first'));
 		Assert::false($sl->isCreated('second'));
 		Assert::false($sl->isCreated('third'));
+		Assert::false($sl->isCreated('fourth'));
+		Assert::false($sl->isCreated('fifth'));
 
 		$all = $lazy->getListeners();
 
 		Assert::true($sl->isCreated('first'));
 		Assert::true($sl->isCreated('second'));
 		Assert::true($sl->isCreated('third'));
+		Assert::true($sl->isCreated('fourth'));
+		Assert::true($sl->isCreated('fifth'));
 
 		Assert::same(array(
 			'App::onFoo' => array(
@@ -110,6 +121,12 @@ class LazyEventManagerTest extends Tester\TestCase
 			'onBaz' => array(
 				$sl->getService('fourth'),
 			),
+			'onQuux' => array(
+				$sl->getService('fifth'),
+			),
+			'onCorge' => array(
+				$sl->getService('fifth'),
+			),
 		), $all);
 	}
 
@@ -124,23 +141,26 @@ class LazyEventManagerTest extends Tester\TestCase
 		$second = $sl->getService('second');
 		$third = $sl->getService('third');
 		$fourth = $sl->getService('fourth');
+		$fifth = $sl->getService('fifth');
 
 		Assert::true($lazy->hasListeners('App::onFoo'));
 		Assert::true($lazy->hasListeners('onFoo'));
 		Assert::true($lazy->hasListeners('onBar'));
-		Assert::true($lazy->hasListeners('onBaz'));
 		Assert::true($lazy->hasListeners('Article::onDiscard'));
+		Assert::true($lazy->hasListeners('onBaz'));
+		Assert::true($lazy->hasListeners('onQuux'));
 
 		$lazy->removeEventSubscriber($first);
 		$lazy->removeEventSubscriber($second);
 		$lazy->removeEventSubscriber($third);
 		$lazy->removeEventListener($fourth); // callable is listener, not subscriber
+		$lazy->removeEventSubscriber($fifth);
 
 		Assert::false($lazy->hasListeners('App::onFoo'));
 		Assert::false($lazy->hasListeners('onFoo'));
 		Assert::false($lazy->hasListeners('onBar'));
-		Assert::false($lazy->hasListeners('onBaz'));
 		Assert::false($lazy->hasListeners('Article::onDiscard'));
+		Assert::false($lazy->hasListeners('onQuux'));
 	}
 
 }
@@ -174,6 +194,13 @@ class ListenersContainer extends Container
 	protected function createServiceFourth()
 	{
 		return function () {};
+	}
+
+
+
+	protected function createServiceFifth()
+	{
+		return new MagicEventListenerMock();
 	}
 
 }

--- a/tests/KdybyTests/Events/mocks.php
+++ b/tests/KdybyTests/Events/mocks.php
@@ -199,6 +199,34 @@ class EventListenerMock implements Kdyby\Events\Subscriber
 
 }
 
+/**
+ * @author Filip Procházka <filip@prochazka.su>
+ */
+class MagicEventListenerMock implements Kdyby\Events\Subscriber
+{
+
+	public $calls = array();
+
+	/**
+	 * @return array
+	 */
+	public function getSubscribedEvents()
+	{
+		return array(
+			'onQuux',
+			'onCorge',
+		);
+	}
+
+	public function __call($name, $arguments)
+	{
+		$args = $arguments[0];
+		$args->calls[] = array(__CLASS__ . '::' . $name, $arguments);
+		$this->calls[] = array(__CLASS__ . '::' . $name, $arguments);
+	}
+
+}
+
 
 
 /**

--- a/tests/KdybyTests/Events/mocks.php
+++ b/tests/KdybyTests/Events/mocks.php
@@ -165,7 +165,7 @@ class EventArgsMock extends Kdyby\Events\EventArgs
 /**
  * @author Filip Procházka <filip@prochazka.su>
  */
-class EventListenerMock extends Nette\Object implements Kdyby\Events\Subscriber
+class EventListenerMock implements Kdyby\Events\Subscriber
 {
 
 	public $calls = array();


### PR DESCRIPTION
Closes #57 

In some cases I would like use dynamic listeners or use callbacks as listeners.

It was not possible before and this PR adds the functionality requested in #57.

In cases when I would like use callbacks almost everytime is it possible to create Subscriber which supplies the functionality. So I'm not 100% sure that the feature is really needed.

Does anybody has a specific use case when callback or __call methods are better than "real classes with real methods"?