### PR TITLE
Fixed faulty loop management when unsubscribing listeners

### DIFF
--- a/src/Kdyby/Events/EventManager.php
+++ b/src/Kdyby/Events/EventManager.php
@@ -216,6 +216,10 @@ class EventManager extends Doctrine\Common\EventManager
 					break;
 				}
 
+				if(!isset($key)) {
+					continue;
+				}
+
 				unset($this->listeners[$eventName][$priority][$key]);
 				if (empty($this->listeners[$eventName][$priority])) {
 					unset($this->listeners[$eventName][$priority]);
@@ -229,6 +233,7 @@ class EventManager extends Doctrine\Common\EventManager
 					unset($this->sorted[$eventName]);
 				}
 
+				unset($key);
 			}
 		}
 	}

--- a/src/Kdyby/Events/EventManager.php
+++ b/src/Kdyby/Events/EventManager.php
@@ -210,7 +210,7 @@ class EventManager extends Doctrine\Common\EventManager
 			foreach ($this->listeners[$eventName] as $priority => $listeners) {
 				foreach ($listeners as $k => $listener) {
 					if (!($listener == $subscriber || (is_array($listener) && $listener[0] == $subscriber))) {
-						continue(2);
+						continue;
 					}
 					$key = $k;
 					break;


### PR DESCRIPTION
There's a bug in the nested foreach loop. 

It iterates over all listeners for the given event, searching for the index of the subscriber, that should be unsubscribed for this event. When the subscriber in the current iteration isn't the one we're looking for, it should continue to the next one. However there's `continue(2)` instead, which causes all other subscribers to be skipped and the loop continues with next event. 

The result is that, if the subscriber is first in the array of subscribers for a given event, it's successfully unsubscribed as expected. If it's not the first, then it won't be unsubscribed because the whole array will be skipped.

This commit fixes the bug, changing `continue(2)` to `continue` to properly continue to another subscriber in the array.
