### PR TITLE
Add option to disable symfony proxy

### DIFF
--- a/src/Kdyby/Events/DI/EventsExtension.php
+++ b/src/Kdyby/Events/DI/EventsExtension.php
@@ -43,6 +43,7 @@ class EventsExtension extends Nette\DI\CompilerExtension
 		'debugger' => '%debugMode%',
 		'exceptionHandler' => NULL,
 		'globalDispatchFirst' => FALSE,
+		'symfonyProxy' => TRUE,
 	];
 
 	/**
@@ -114,7 +115,7 @@ class EventsExtension extends Nette\DI\CompilerExtension
 			$def->addTag(self::SUBSCRIBER_TAG);
 		}
 
-		if (class_exists('Symfony\Component\EventDispatcher\Event')) {
+		if (class_exists('Symfony\Component\EventDispatcher\Event') && $config['symfonyProxy']) {
 			$builder->addDefinition($this->prefix('symfonyProxy'))
 				->setClass('Symfony\Component\EventDispatcher\EventDispatcherInterface')
 				->setFactory('Kdyby\Events\SymfonyDispatcher');

--- a/tests/KdybyTests/Events/config/noSymfonyProxy.neon
+++ b/tests/KdybyTests/Events/config/noSymfonyProxy.neon
@@ -1,0 +1,2 @@
+events:
+	symfonyProxy: no


### PR DESCRIPTION
Turns out that https://github.com/Arachne/EventDispatcher is incompatible with Kdyby/Events (multiple dispatcher services). I could hack it in my package the same way as in Symnedi/EventDispatcher but I'd rather avoid that.

There is no BC break (the dispatcher proxy is still enabled by default).