### PR TITLE
Fix for nette/tester 2.0

### DIFF
--- a/tests/KdybyTests/bootstrap.php
+++ b/tests/KdybyTests/bootstrap.php
@@ -33,5 +33,5 @@ function id($val) {
 }
 
 function run(Tester\TestCase $testCase) {
-	$testCase->run(isset($_SERVER['argv'][1]) ? $_SERVER['argv'][1] : NULL);
+	$testCase->run();
 }


### PR DESCRIPTION
With nette 2.4, most component depends on nette/tester 2.0 (not yet released, see https://github.com/nette/tester/issues/325)

Running test suite fails with: 

```
+ php71 /usr/bin/nette-tester --colors 0 -p php71 -C tests/KdybyTests -s
 _____ ___  ___ _____ ___  ___
|_   _/ __)( __/_   _/ __)| _ )
  |_| \___ /___) |_| \___ |_|_\  v2.0.x

PHP 7.1.0beta2 (cli) | php71 | 8 threads

FFFFFFF

-- FAILED: Kdyby\Events\Event. | KdybyTests/Events/Event.phpt
   LogicException: Calling TestCase::run($method) is deprecated. Use TestCase::runTest($method) instead.
   
   in Tester/Framework/TestCase.php(35) 
   in tests/KdybyTests/bootstrap.php(36) Tester\TestCase->run()
   in KdybyTests/Events/Event.phpt(240) run()

-- FAILED: Kdyby\Events\EventArgs. | KdybyTests/Events/EventArgs.phpt
   LogicException: Calling TestCase::run($method) is deprecated. Use TestCase::runTest($method) instead.
   
   in Tester/Framework/TestCase.php(35) 
   in tests/KdybyTests/bootstrap.php(36) Tester\TestCase->run()
   in KdybyTests/Events/EventArgs.phpt(36) run()

-- FAILED: Kdyby\Events\EventManager. | KdybyTests/Events/EventManager.phpt
   LogicException: Calling TestCase::run($method) is deprecated. Use TestCase::runTest($method) instead.
   
   in Tester/Framework/TestCase.php(35) 
   in tests/KdybyTests/bootstrap.php(36) Tester\TestCase->run()
   in KdybyTests/Events/EventManager.phpt(473) run()

-- FAILED: Kdyby\Events\Extension. | KdybyTests/Events/Extension.phpt
   LogicException: Calling TestCase::run($method) is deprecated. Use TestCase::runTest($method) instead.
   
   in Tester/Framework/TestCase.php(35) 
   in tests/KdybyTests/bootstrap.php(36) Tester\TestCase->run()
   in KdybyTests/Events/Extension.phpt(357) run()

-- FAILED: Kdyby\Events\IExceptionHandler. | KdybyTests/Events/IExceptionHandler.phpt
   LogicException: Calling TestCase::run($method) is deprecated. Use TestCase::runTest($method) instead.
   
   in Tester/Framework/TestCase.php(35) 
   in tests/KdybyTests/bootstrap.php(36) Tester\TestCase->run()
   in KdybyTests/Events/IExceptionHandler.phpt(68) run()

-- FAILED: Kdyby\Events\LazyEventManager. | KdybyTests/Events/LazyEventManager.phpt
   LogicException: Calling TestCase::run($method) is deprecated. Use TestCase::runTest($method) instead.
   
   in Tester/Framework/TestCase.php(35) 
   in tests/KdybyTests/bootstrap.php(36) Tester\TestCase->run()
   in KdybyTests/Events/LazyEventManager.phpt(210) run()

-- FAILED: Kdyby\Events\NamespacedEventManager. | KdybyTests/Events/NamespacedEventManager.phpt
   LogicException: Calling TestCase::run($method) is deprecated. Use TestCase::runTest($method) instead.
   
   in Tester/Framework/TestCase.php(35) 
   in tests/KdybyTests/bootstrap.php(36) Tester\TestCase->run()
   in KdybyTests/Events/NamespacedEventManager.phpt(111) run()


FAILURES! (7 tests, 7 failures, 0.3 seconds)

```

This trivial fix seems enough