### PR TITLE
Add nette/reflection to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 	},
 	"require": {
 		"nette/di": "~2.3@dev",
-		"nette/utils": "~2.3@dev"
+		"nette/utils": "~2.3@dev",
+		"nette/reflection": "~2.3@dev"
 	},
 	"require-dev": {
 		"nette/application": "~2.3@dev",


### PR DESCRIPTION
EventsExtension uses nette/reflection classes but the dependency is missing in composer.json. Today one of my builds failed because of that: https://travis-ci.org/Zenify/DoctrineFixtures/jobs/164474624

This is just a hotfix. Better fix would be to remove usage of nette/reflection.
