### PR TITLE
EventsExtension::optimizeListeners() - fix of invalid condition

### DIFF
--- a/src/Events/DI/EventsExtension.php
+++ b/src/Events/DI/EventsExtension.php
@@ -383,7 +383,7 @@ class EventsExtension extends \Nette\DI\CompilerExtension
 				// find all subclasses and register the listener to all the classes dispatching them
 				foreach ($builder->getDefinitions() as $def) {
 					$class = $def->getClass();
-					if (!empty($class)) {
+					if (!$class) {
 						continue; // ignore unresolved classes
 					}
 


### PR DESCRIPTION
Fix of invalid conditions causing rewritten services not handling ancestors events.