### PR TITLE
Composer require "php:^7.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache:
         - $HOME/.composer/cache
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"issues": "https://github.com/kdyby/events/issues"
 	},
 	"require": {
-		"php": "^5.6 || ^7.0",
+		"php": "^7.1",
 		"nette/di": "^2.4.8@dev",
 		"nette/utils": "^2.4.5@dev",
 		"nette/reflection": "^2.4@dev",


### PR DESCRIPTION
Remove support for PHP 5.6, 7.0 and require PHP version 7.1 and higher