### PR TITLE
Fix build

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,3 +3,8 @@ parameters:
 	paths:
 		- src
 		- tests/KdybyTests
+
+	ignoreErrors:
+		-
+			message: '~Parameter \#1 \$eventName \(string\) of method Kdyby\\Events\\SymfonyDispatcher::dispatch\(\) should be compatible with parameter \$event \(object\) of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\)~'
+			path: src/Events/SymfonyDispatcher.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,3 +8,6 @@ parameters:
 		-
 			message: '~Parameter \#1 \$eventName \(string\) of method Kdyby\\Events\\SymfonyDispatcher::dispatch\(\) should be compatible with parameter \$event \(object\) of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\)~'
 			path: src/Events/SymfonyDispatcher.php
+		-
+			message: '~Parameter \#1 \$classname of function class_exists expects string, Nette\\DI\\Definitions\\Reference\|string given.~'
+			path: src/Events/DI/EventsExtension.php

--- a/src/Events/SymfonyDispatcher.php
+++ b/src/Events/SymfonyDispatcher.php
@@ -26,6 +26,9 @@ class SymfonyDispatcher implements \Symfony\Component\EventDispatcher\EventDispa
 		$this->evm = $eventManager;
 	}
 
+	/**
+	 * @param string $eventName
+	 */
 	public function dispatch($eventName, SymfonyEvent $event = NULL)
 	{
 		$this->evm->dispatchEvent($eventName, new EventArgsList([$event]));


### PR DESCRIPTION
Error in `SymfonyDispatcher` is probably not fixable as this package only (AFAIK) (ab?)uses the interface as a proxy to its own EventManager.

I also believe that the case with `Reference` being passed to `class_exists` in `EventsExtension` won't occur. If someone is able to provide a counter-example, I'll fix that and cover with tests.

I'd love to see a new release being tagged 🙃 